### PR TITLE
Set cusor on componentDidMount

### DIFF
--- a/app/assets/javascripts/components/note_editor.js.jsx.coffee
+++ b/app/assets/javascripts/components/note_editor.js.jsx.coffee
@@ -1,4 +1,8 @@
 @NoteEditor = React.createClass
+  componentDidMount: ->
+    el = document.getElementById('note_text')
+    el.focus()
+    el.setSelectionRange(el.value.length, el.value.length)
   render: ->
     `<form><textarea id="note_text" ref="text" onInput={this.persistNote} defaultValue={this.props.note.text}></textarea></form>`
 

--- a/app/assets/stylesheets/notes.scss
+++ b/app/assets/stylesheets/notes.scss
@@ -3,7 +3,6 @@
   top: 0; left: 0;
   width: 100%;
   height: 100%;
-
 }
 
 .note-editor textarea {
@@ -16,6 +15,7 @@
   font-family: Monaco, Courier, fixed;
   &:focus {
     outline: 0;
+    cursor: text;
   }
 }
 


### PR DESCRIPTION
I thought I did something wrong when I loaded this the first time because the `textarea` element is only about 50px high, and the cursor on the `body` element is default, so it just looked like a blank page. It took me a few minutes of head scratching and looking at the code to figure out what was going on.

This PR focuses the element on `componentDidMount` and makes sure the cursor is a text one. It also starts the cursor at the end of the `textarea`'s value so that if you have, say, two notes added, it starts on the third line.